### PR TITLE
Start fixing the I/O Parameters Properties view

### DIFF
--- a/plugins/org.eclipse.bpmn2.modeler.core/src/org/eclipse/bpmn2/modeler/core/merrimac/clad/AbstractBpmn2PropertySection.java
+++ b/plugins/org.eclipse.bpmn2.modeler.core/src/org/eclipse/bpmn2/modeler/core/merrimac/clad/AbstractBpmn2PropertySection.java
@@ -172,7 +172,9 @@ public abstract class AbstractBpmn2PropertySection extends GFPropertySection imp
 		if (parent!=null && !parent.isDisposed()) {
 			if (parent.getChildren().length==0) {
 				sectionRoot = createSectionRoot();
-				sectionRoot.setLayoutData(new GridData(SWT.FILL,SWT.FILL,true,false,1,1));
+				sectionRoot.setLayout( new GridLayout(1, false));
+				sectionRoot.setLayoutData(new GridData(SWT.FILL,SWT.FILL,true,true,1,1));
+
 			}
 			sectionRoot = (AbstractDetailComposite)parent.getChildren()[0];
 		}

--- a/plugins/org.eclipse.bpmn2.modeler.core/src/org/eclipse/bpmn2/modeler/core/merrimac/clad/AbstractListComposite.java
+++ b/plugins/org.eclipse.bpmn2.modeler.core/src/org/eclipse/bpmn2/modeler/core/merrimac/clad/AbstractListComposite.java
@@ -380,7 +380,7 @@ public abstract class AbstractListComposite extends ListAndDetailCompositeBase i
 			// display title in the table section and/or show a details section
 			// SHOW_DETAILS forces drawing of a section title
 			sashForm = new SashForm(this, SWT.NONE);
-			sashForm.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 3, 1));
+			sashForm.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1));
 			
 			tableSection = createListSection(sashForm,label);
 			

--- a/plugins/org.eclipse.bpmn2.modeler.runtime.jboss.jbpm5/src/org/eclipse/bpmn2/modeler/runtime/jboss/jbpm5/property/JbpmIoParametersListComposite.java
+++ b/plugins/org.eclipse.bpmn2.modeler.runtime.jboss.jbpm5/src/org/eclipse/bpmn2/modeler/runtime/jboss/jbpm5/property/JbpmIoParametersListComposite.java
@@ -41,6 +41,9 @@ public class JbpmIoParametersListComposite extends IoParametersListComposite {
 			InputOutputSpecification ioSpecification,
 			EStructuralFeature ioFeature) {
 		super(detailComposite, container, ioSpecification, ioFeature);
+		setLayout(new GridLayout(1, false));
+		setLayoutData(new GridData(SWT.FILL,SWT.FILL,true,true,1,1)); 
+
 	}
 	
 	@Override


### PR DESCRIPTION
Currently the usability of Properties/I/O Parameters view is non existant. This is a first attempt to make some sense of the ui. Simple try to use all the available space (by using SWT.FILL where possible).

Initial view of I/O Parameters before the patch (aka current situtation): 
![image](https://cloud.githubusercontent.com/assets/3129138/6555924/63dcc0d0-c672-11e4-954b-77bd800a2ab2.png)

Initial view of I/O Parameters after applying the patch:
![kuvakaappaus 2015-03-09 15 34 45](https://cloud.githubusercontent.com/assets/3129138/6555867/fdeac3da-c671-11e4-9521-a80108fb2ef7.png)

This is still just a start and there're still very serious usablity issues present in the I/O Parameters screen.