### PR TITLE
Don't restrict widths of rectangles on import.

### DIFF
--- a/plugins/org.eclipse.bpmn2.modeler.core/src/org/eclipse/bpmn2/modeler/core/features/activity/AbstractAddActivityFeature.java
+++ b/plugins/org.eclipse.bpmn2.modeler.core/src/org/eclipse/bpmn2/modeler/core/features/activity/AbstractAddActivityFeature.java
@@ -73,7 +73,7 @@ public abstract class AbstractAddActivityFeature<T extends Activity>
 		
 		GraphicsAlgorithm targetAlgorithm = context.getTargetContainer().getGraphicsAlgorithm();
 		
-		if (targetAlgorithm != null) {
+		if (targetAlgorithm != null && !(targetAlgorithm instanceof Rectangle)) {
 			width = Math.min(targetAlgorithm.getWidth(), width);
 			height = Math.min(targetAlgorithm.getHeight(), height);
 		}


### PR DESCRIPTION
Currently diagrams with large subprocesses have widths and heights
clipped to 1000 on load, which causes the contents to be clipped.